### PR TITLE
Keep only the necessary code for the public repo

### DIFF
--- a/model.py
+++ b/model.py
@@ -1,10 +1,7 @@
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
-import numpy as np
-from losses.losses import SupConLoss
-from btcvae import KL
-from utils import log_normal, log_normal_mixture, imq_kernel
+from utils import log_normal, log_normal_mixture
 
 device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
 
@@ -12,63 +9,49 @@ class VAE(nn.Module):
     def __init__(self, args):
         super(VAE, self).__init__()
         self.args = args
-        # feature layers
-        input_dim = args.feature_dim+args.meta_offset
-        self.fx1 = nn.Linear(input_dim, 256)
-        self.fx2 = nn.Linear(256, 512)
-        self.fx3 = nn.Linear(512, 256)
+        self.dropout = nn.Dropout(p=args.keep_prob)
+        
+        """Feature encoder"""
+        self.fx = nn.Sequential(
+            nn.Linear(args.feature_dim, 256),
+            nn.ReLU(),
+            self.dropout,
+            nn.Linear(256, 512),
+            nn.ReLU(),
+            self.dropout,
+            nn.Linear(512, 256),
+            nn.ReLU(),
+            self.dropout
+        )
         self.fx_mu = nn.Linear(256, args.latent_dim)
         self.fx_logvar = nn.Linear(256, args.latent_dim)
 
-        self.emb_size = args.emb_size
-
-        self.fd_x1 = nn.Linear(input_dim+args.latent_dim, 512)
-        self.fd_x2 = torch.nn.Sequential(
-            nn.Linear(512, self.emb_size)
-        )
-        self.feat_mp_mu = nn.Linear(self.emb_size, args.label_dim)
-
-        self.recon = torch.nn.Sequential(
-            nn.Linear(args.latent_dim, 512),
+        """Label encoder"""
+        self.label_lookup = nn.Linear(args.label_dim, args.emb_size)
+        self.fe = nn.Sequential(
+            nn.Linear(args.emb_size, 512),
             nn.ReLU(),
-            nn.Linear(512, 512),
+            self.dropout,
+            nn.Linear(512, 256),
             nn.ReLU(),
-            nn.Linear(512, input_dim)
+            self.dropout
         )
-
-        self.label_recon = torch.nn.Sequential(
-            nn.Linear(args.latent_dim, 512),
-            nn.ReLU(),
-            nn.Linear(512, self.emb_size),
-            nn.LeakyReLU()
-        )
-
-        # label layers
-        self.fe0 = nn.Linear(args.label_dim, self.emb_size)
-        self.fe1 = nn.Linear(self.emb_size, 512)
-        self.fe2 = nn.Linear(512, 256)
         self.fe_mu = nn.Linear(256, args.latent_dim)
         self.fe_logvar = nn.Linear(256, args.latent_dim)
 
-        self.fd1 = self.fd_x1
-        self.fd2 = self.fd_x2
-        self.label_mp_mu = self.feat_mp_mu
-
-        self.bias = nn.Parameter(torch.zeros(args.label_dim))
-
-        assert id(self.fd_x1) == id(self.fd1)
-        assert id(self.fd_x2) == id(self.fd2)
-
-        # things they share
-        self.dropout = nn.Dropout(p=args.keep_prob)
-        self.scale_coeff = args.scale_coeff
+        """Decoder"""
+        self.fd = nn.Sequential(
+            nn.Linear(args.feature_dim + args.latent_dim, 512),
+            nn.ReLU(),
+            nn.Linear(512, args.emb_size),
+            nn.LeakyReLU()
+        )
 
     def label_encode(self, x):
-        h0 = self.dropout(F.relu(self.fe0(x)))
-        h1 = self.dropout(F.relu(self.fe1(h0)))
-        h2 = self.dropout(F.relu(self.fe2(h1)))
-        mu = self.fe_mu(h2) * self.scale_coeff
-        logvar = self.fe_logvar(h2) * self.scale_coeff
+        h0 = self.dropout(F.relu(self.label_lookup(x)))
+        h = self.fe(h0)
+        mu = self.fe_mu(h)
+        logvar = self.fe_logvar(h)
         fe_output = {
             'fe_mu': mu,
             'fe_logvar': logvar
@@ -76,65 +59,30 @@ class VAE(nn.Module):
         return fe_output
 
     def feat_encode(self, x):
-        h1 = self.dropout(F.relu(self.fx1(x)))
-        h2 = self.dropout(F.relu(self.fx2(h1)))
-        h3 = self.dropout(F.relu(self.fx3(h2)))
-        mu = self.fx_mu(h3) * self.scale_coeff
-        logvar = self.fx_logvar(h3) * self.scale_coeff
+        h = self.fx(x)
+        mu = self.fx_mu(h)
+        logvar = self.fx_logvar(h)
         fx_output = {
             'fx_mu': mu,
             'fx_logvar': logvar
         }
-        
         return fx_output
 
-    def label_reparameterize(self, mu, logvar):
-        std = torch.exp(0.5*logvar)
-        eps = torch.randn_like(std)
-        return mu + eps*std
-
-    def feat_reparameterize(self, mu, logvar, coeff=1.0):
-        std = torch.exp(0.5*logvar)
-        eps = torch.randn_like(std)
-        return mu + eps*std
-
-    def label_decode(self, z):
-        d1 = F.relu(self.fd1(z))
-        d2 = F.leaky_relu(self.fd2(d1))
-        d3 = F.normalize(d2, dim=1)
-        return d3
-
-    def feat_decode(self, z):
-        d1 = F.relu(self.fd_x1(z))
-        d2 = F.leaky_relu(self.fd_x2(d1))
-        d3 = F.normalize(d2, dim=1)
-        return d3
+    def decode(self, z):
+        d = self.fd(z)
+        d = F.normalize(d, dim=1)
+        return d
 
     def label_forward(self, x, feat):
-        if self.args.reg == "gmvae":
-            n_label = x.shape[1]
-            all_labels = torch.eye(n_label).to(x.device)
-            fe_output = self.label_encode(all_labels)
-        else:
-            fe_output = self.label_encode(x)
+        n_label = x.shape[1]
+        all_labels = torch.eye(n_label).to(device)
+        fe_output = self.label_encode(all_labels)
         mu = fe_output['fe_mu']
-        logvar = fe_output['fe_logvar']
         
-        if self.args.reg == "wae" or not self.training:
-            if self.args.reg == "gmvae":
-                z = torch.matmul(x, mu) / x.sum(1, keepdim=True)
-            else:
-                z = mu
-        else:
-            if self.args.reg == "gmvae":
-                z = torch.matmul(x, mu) / x.sum(1, keepdim=True)
-            else:
-                z = self.label_reparameterize(mu, logvar)
-        label_emb = self.label_decode(torch.cat((feat, z), 1))
-        single_label_emb = F.normalize(self.label_recon(mu), dim=1)
+        z = torch.matmul(x, mu) / x.sum(1, keepdim=True)
+        label_emb = self.decode(torch.cat((feat, z), 1))
 
         fe_output['label_emb'] = label_emb
-        fe_output['single_label_emb'] = single_label_emb
         return fe_output
 
     def feat_forward(self, x):
@@ -142,34 +90,26 @@ class VAE(nn.Module):
         mu = fx_output['fx_mu']
         logvar = fx_output['fx_logvar']
 
-        if self.args.reg == "wae" or not self.training:
-            if self.args.test_sample:
-                z = self.feat_reparameterize(mu, logvar)
-                z2 = self.feat_reparameterize(mu, logvar)
-            else:
-                z = mu
-                z2 = mu
+        if not self.training:
+            z = mu
+            z2 = mu
         else:
-            z = self.feat_reparameterize(mu, logvar)
-            z2 = self.feat_reparameterize(mu, logvar)
-        feat_emb = self.feat_decode(torch.cat((x, z), 1))
-        feat_emb2 = self.feat_decode(torch.cat((x, z2), 1))
+            z = reparameterize(mu, logvar)
+            z2 = reparameterize(mu, logvar)
+        feat_emb = self.decode(torch.cat((x, z), 1))
+        feat_emb2 = self.decode(torch.cat((x, z2), 1))
         fx_output['feat_emb'] = feat_emb
         fx_output['feat_emb2'] = feat_emb2
-
-        feat_recon = self.recon(z)
-        fx_output['feat_recon'] = feat_recon
         return fx_output
 
     def forward(self, label, feature):
         fe_output = self.label_forward(label, feature)
-        label_emb, single_label_emb = fe_output['label_emb'], fe_output['single_label_emb']
+        label_emb = fe_output['label_emb']
         fx_output = self.feat_forward(feature)
         feat_emb, feat_emb2 = fx_output['feat_emb'], fx_output['feat_emb2']
-        embs = self.fe0.weight
-        
+
+        embs = self.label_lookup.weight
         label_out = torch.matmul(label_emb, embs)
-        single_label_out = torch.matmul(single_label_emb, embs)
         feat_out = torch.matmul(feat_emb, embs)
         feat_out2 = torch.matmul(feat_emb2, embs)
         
@@ -177,122 +117,54 @@ class VAE(nn.Module):
         output = fe_output
         output['embs'] = embs
         output['label_out'] = label_out
-        output['single_label_out'] = single_label_out
         output['feat_out'] = feat_out
         output['feat_out2'] = feat_out2
         output['feat'] = feature
-
         return output
 
-def build_multi_classification_loss(predictions, labels):
-    shape = tuple(labels.shape)
-    labels = labels.float()
-    y_i = torch.eq(labels, torch.ones(shape).to(device))
-    y_not_i = torch.eq(labels, torch.zeros(shape).to(device))
 
-    truth_matrix = pairwise_and(y_i, y_not_i).float()
-    sub_matrix = pairwise_sub(predictions, predictions)
-    exp_matrix = torch.exp(-5*sub_matrix)
-    sparse_matrix = exp_matrix * truth_matrix
-    sums = torch.sum(sparse_matrix, dim=[2,3])
-    y_i_sizes = torch.sum(y_i.float(), dim=1)
-    y_i_bar_sizes = torch.sum(y_not_i.float(), dim=1)
-    normalizers = y_i_sizes * y_i_bar_sizes
-    loss = torch.div(sums, 5*normalizers) # 100*128  divide  128
-    zero = torch.zeros_like(loss) # 100*128 zeros
-    loss = torch.where(torch.logical_or(torch.isinf(loss), torch.isnan(loss)), zero, loss)
-    loss = torch.mean(loss)
-    return loss
-
-def pairwise_and(a, b):
-    column = torch.unsqueeze(a, 2)
-    row = torch.unsqueeze(b, 1)
-    return torch.logical_and(column, row)
-
-def pairwise_sub(a, b):
-    column = torch.unsqueeze(a, 3)
-    row = torch.unsqueeze(b, 2)
-    return column - row
-
-def cross_entropy_loss(logits, labels, n_sample):
-    labels = torch.tile(torch.unsqueeze(labels, 0), [n_sample, 1, 1])
-    ce_loss = nn.BCEWithLogitsLoss(labels=labels, logits=logits)
-    ce_loss = torch.mean(torch.sum(ce_loss, dim=1))
-    return ce_loss
-
-def compute_loss(input_label, output, args=None, epoch=0, class_weights=None):
-    if args.reg == "gumbel":
-        fe_out, fe_mu, fe_logvar, label_emb = output['label_out'], output['fe_mu'], output['fe_logvar'], output['label_emb']
-        fx_out, fx_mu, fx_logvar, feat_emb = output['feat_out'], output['fx_mu'], output['fx_logvar'], output['feat_emb']
-        fx_out2, single_label_out = output['feat_out2'], output['single_label_out']
-        embs = output['embs']
-        feat_recon, feat = output['feat_recon'], output['feat']
-        losses = LossFunctions()
-        fx_loss_cat = -losses.entropy(output['fx_gumbel_logits'], output['fx_gumbel_prob']) - np.log(0.1)
-        fe_loss_cat = -losses.entropy(output['fe_gumbel_logits'], output['fe_gumbel_prob']) - np.log(0.1)
-    else:
-        fe_out, fe_mu, fe_logvar, label_emb = output['label_out'], output['fe_mu'], output['fe_logvar'], output['label_emb']
-        fx_out, fx_mu, fx_logvar, feat_emb = output['feat_out'], output['fx_mu'], output['fx_logvar'], output['feat_emb']
-        fx_out2, single_label_out = output['feat_out2'], output['single_label_out']
-        embs = output['embs']
-
-    feat_recon_loss = 0.
-
-    latent_cpc_loss = 0.
-    if args.reg == "gmvae":
-        fe_sample = torch.matmul(input_label, fe_mu) / input_label.sum(1, keepdim=True)
-        latent_cpc_loss = SupConLoss(temperature=0.1)(torch.stack([fe_sample, fx_mu], dim=1), input_label.float())
-    else:
-        latent_cpc_loss = SupConLoss(temperature=0.1)(torch.stack([fe_mu, fx_mu], dim=1), input_label.float())
+def reparameterize(mu, logvar):
+    std = torch.exp(0.5*logvar)
+    eps = torch.randn_like(std)
+    return mu + eps*std
 
 
-    if args.reg == "vae":
-        kl_loss = torch.mean(0.5*torch.sum((fx_logvar-fe_logvar)-1+torch.exp(fe_logvar-fx_logvar)+torch.square(fx_mu-fe_mu)/(torch.exp(fx_logvar)+1e-6), dim=1))
-    elif args.reg == "btcae":
-        std = torch.exp(0.5*fx_logvar)
-        eps = torch.randn_like(std)
-        fx_sample = fx_mu + eps*std
-        kl_loss = KL((fe_mu, fe_logvar), fx_sample)
-    elif args.reg == "wae":
-        kl_loss = 0.
-        for i in range(10):
-            std = torch.exp(0.5*fx_logvar)
-            eps = torch.randn_like(std)
-            fx_sample = fx_mu + eps*std
-            kl_loss += imq_kernel(fe_mu, fx_sample, h_dim=fx_mu.shape[1])
-        kl_loss /= 10.
-        kl_loss *= 5
-    elif args.reg == "gmvae":
-        std = torch.exp(0.5*fx_logvar)
-        eps = torch.randn_like(std)
-        fx_sample = fx_mu + eps*std
-        fx_var = torch.exp(fx_logvar)
-        fe_var = torch.exp(fe_logvar)
-        kl_loss = (log_normal(fx_sample, fx_mu, fx_var) - log_normal_mixture(fx_sample, fe_mu, fe_var, input_label)).mean()
+def compute_loss(input_label, output, args=None):
+    fe_out, fe_mu, fe_logvar, label_emb = \
+        output['label_out'], output['fe_mu'], output['fe_logvar'], output['label_emb']
+    fx_out, fx_mu, fx_logvar, feat_emb = \
+        output['feat_out'], output['fx_mu'], output['fx_logvar'], output['feat_emb']
+    fx_out2 = output['feat_out2']
+    embs = output['embs']
+
+    fx_sample = reparameterize(fx_mu, fx_logvar)
+    fx_var = torch.exp(fx_logvar)
+    fe_var = torch.exp(fe_logvar)
+    kl_loss = (log_normal(fx_sample, fx_mu, fx_var) - \
+        log_normal_mixture(fx_sample, fe_mu, fe_var, input_label)).mean()
+
+    pred_e = torch.sigmoid(fe_out)
+    pred_x = torch.sigmoid(fx_out)
+    pred_x2 = torch.sigmoid(fx_out2)
 
     def compute_BCE_and_RL_loss(E):
         #compute negative log likelihood (BCE loss) for each sample point
-        sample_nll = -(torch.log(E)*input_label+torch.log(1-E)*(1-input_label))
-        
-        logprob=-torch.sum(sample_nll, dim=2)
+        sample_nll = -(
+            torch.log(E) * input_label + torch.log(1 - E) * (1 - input_label)
+        )
+        logprob = -torch.sum(sample_nll, dim=2)
 
         #the following computation is designed to avoid the float overflow (log_sum_exp trick)
-        maxlogprob=torch.max(logprob, dim=0)[0]
-        Eprob=torch.mean(torch.exp(logprob-maxlogprob), axis=0)
-        nll_loss=torch.mean(-torch.log(Eprob)-maxlogprob)
-
-        #c_loss = build_multi_classification_loss(E, input_label)
+        maxlogprob = torch.max(logprob, dim=0)[0]
+        Eprob = torch.mean(torch.exp(logprob - maxlogprob), axis=0)
+        nll_loss = torch.mean(-torch.log(Eprob) - maxlogprob)
         return nll_loss
 
-    def supconloss(label_emb, feat_emb, embs, temp=1.0, sample_wise=False):
-        if sample_wise:
-            loss_func = SupConLoss(temperature=0.1)
-            return loss_func(torch.stack([label_emb, feat_emb], dim=1), input_label.float())
-
+    def supconloss(label_emb, feat_emb, embs, temp=1.0):
         features = torch.cat((label_emb, feat_emb))
         labels = torch.cat((input_label, input_label)).float()
         n_label = labels.shape[1]
-        emb_labels = torch.eye(n_label).to(feat_emb.device)
+        emb_labels = torch.eye(n_label).to(device)
         mask = torch.matmul(labels, emb_labels)
 
         anchor_dot_contrast = torch.div(
@@ -305,31 +177,14 @@ def compute_loss(input_label, output, args=None, epoch=0, class_weights=None):
         log_prob = logits - torch.log(exp_logits.sum(1, keepdim=True))
 
         mean_log_prob_pos = (mask * log_prob).sum(1) / mask.sum(1)
-        mean_log_prob_neg = ((1.0-mask) * log_prob).sum(1) / (1.0-mask).sum(1)
-
-        loss = - mean_log_prob_pos
+        loss = -mean_log_prob_pos
         loss = loss.mean()
-
         return loss
 
-    if not args.finetune:
-        pred_e = torch.sigmoid(fe_out)
-        pred_x = torch.sigmoid(fx_out)
-        pred_x2 = torch.sigmoid(fx_out2)
-        pred_single_label = torch.sigmoid(single_label_out)
-        single_label_recon_loss = nn.BCELoss()(pred_single_label, torch.eye(pred_single_label.shape[1]).to(pred_single_label.device))
-        
-        nll_loss = compute_BCE_and_RL_loss(pred_e.unsqueeze(0))
-        nll_loss_x = compute_BCE_and_RL_loss(pred_x.unsqueeze(0))
-        nll_loss_x2 = compute_BCE_and_RL_loss(pred_x2.unsqueeze(0))
-        cpc_loss = supconloss(label_emb, feat_emb, embs, sample_wise=args.cpc_sample_wise)
-        total_loss = (nll_loss + nll_loss_x + nll_loss_x2) * args.nll_coeff + kl_loss*6. + (cpc_loss) #+ latent_cpc_loss
-    else:
-        pred_x = torch.sigmoid(fx_out)
-        pred_e = torch.ones_like(pred_x)
-        nll_loss_x, c_loss_x = compute_BCE_and_RL_loss(pred_x.unsqueeze(0))
-        nll_loss, c_loss = 0., 0.
-        total_loss = nll_loss_x * args.nll_coeff + c_loss_x * args.c_coeff + kl_loss
-
-    return total_loss, nll_loss, nll_loss_x, 0., 0., kl_loss, cpc_loss, latent_cpc_loss, single_label_recon_loss, pred_e, pred_x
-
+    nll_loss = compute_BCE_and_RL_loss(pred_e.unsqueeze(0))
+    nll_loss_x = compute_BCE_and_RL_loss(pred_x.unsqueeze(0))
+    nll_loss_x2 = compute_BCE_and_RL_loss(pred_x2.unsqueeze(0))
+    sum_nll_loss = nll_loss + nll_loss_x + nll_loss_x2
+    cpc_loss = supconloss(label_emb, feat_emb, embs)
+    total_loss = sum_nll_loss * args.nll_coeff + kl_loss * 6. + cpc_loss
+    return total_loss, nll_loss, nll_loss_x, 0., 0., kl_loss, cpc_loss, pred_e, pred_x

--- a/script/run_test_mirflickr.sh
+++ b/script/run_test_mirflickr.sh
@@ -1,1 +1,0 @@
-python main.py --data_dir data/mirflickr/mirflickr_data.npy --test_idx data/mirflickr/mirflickr_test_idx.npy --label_dim 38 --z_dim 38 --feature_dim 1000 --nll_coeff 0.5 --c_coeff 0.0 --batch_size 64 --mode test --emb_size 2048 --reg gmvae -cp model/model_mirflickr/vae-ckpt

--- a/test.py
+++ b/test.py
@@ -21,8 +21,8 @@ def test(args):
     #print(labels.sum(0))
 
     print('building network...')
-    vae = VAE(args).to(device)
-    vae.load_state_dict(torch.load(args.checkpoint_path))
+    vae = VAE(args)
+    vae.load_state_dict(torch.load(args.checkpoint_path, map_location=device))
     vae.eval()
 
     print("loaded model: %s" % (args.checkpoint_path))
@@ -59,13 +59,13 @@ def test(args):
 
             with torch.no_grad():
                 output = vae(input_label, input_feat) 
-                total_loss, nll_loss, nll_loss_x, c_loss, c_loss_x, kl_loss, cpc_loss, _, _,  _, pred_x = compute_loss(input_label, output, args)
+                total_loss, nll_loss, nll_loss_x, c_loss, c_loss_x, kl_loss, cpc_loss, _, pred_x = compute_loss(input_label, output, args)
 
             all_nll_loss += nll_loss*(end-start)
             all_c_loss += c_loss*(end-start)
             all_total_loss += total_loss*(end-start)
 
-            if (all_pred_x == []):
+            if len(all_pred_x) == 0: 
                 all_pred_x = pred_x.cpu().data.numpy()
                 all_label = input_label.cpu().data.numpy()
                 all_feat_mu = output['fx_mu'].cpu().data.numpy()

--- a/train.py
+++ b/train.py
@@ -177,8 +177,8 @@ def train(args):
             if args.residue_sigma == "random":
                 pass
             else:
-                total_loss, nll_loss, nll_loss_x, c_loss, c_loss_x, kl_loss, cpc_loss, latent_cpc_loss, feat_recon_loss, _, pred_x = compute_loss(
-                        input_label, output, args, one_epoch, class_weights)
+                total_loss, nll_loss, nll_loss_x, c_loss, c_loss_x, kl_loss, cpc_loss, _, pred_x = \
+                    compute_loss(input_label, output, args)
 
             total_loss.backward()
             optimizer.step()
@@ -218,8 +218,8 @@ def train(args):
                 temp_label = np.reshape(np.array(temp_label, dtype=object), (-1))
                 
                 time_str = datetime.datetime.now().isoformat()
-                print("step=%d  %s\nmacro_f1=%.6f, micro_f1=%.6f\nnll_loss=%.6f\tnll_loss_x=%.6f\nc_loss=%.6f\tc_loss_x=%.6f\tkl_loss=%.6f\tcpc_loss=%.6f\nlatent_cpc_loss=%.6f\tfeat_recon_loss=%.6f\ttotal_loss=%.6f\n" % (
-                    current_step, time_str, macro_f1, micro_f1, nll_loss*args.nll_coeff, nll_loss_x*args.nll_coeff, c_loss*args.c_coeff, c_loss_x*args.c_coeff, kl_loss, cpc_loss, latent_cpc_loss, feat_recon_loss, total_loss))
+                print("step=%d  %s\nmacro_f1=%.6f, micro_f1=%.6f\nnll_loss=%.6f\tnll_loss_x=%.6f\nc_loss=%.6f\tc_loss_x=%.6f\tkl_loss=%.6f\tcpc_loss=%.6f\ttotal_loss=%.6f\n" % (
+                    current_step, time_str, macro_f1, micro_f1, nll_loss*args.nll_coeff, nll_loss_x*args.nll_coeff, c_loss*args.c_coeff, c_loss_x*args.c_coeff, kl_loss, cpc_loss, total_loss))
                 temp_pred_x=[]
                 temp_label=[]
 
@@ -308,8 +308,8 @@ def valid(data, vae, summary_writer, valid_idx, current_step, args, extra=None):
 
         with torch.no_grad():
             output = vae(input_label, input_feat) 
-            total_loss, nll_loss, nll_loss_x, c_loss, c_loss_x, kl_loss, cpc_loss, latent_cpc_loss, feat_recon_loss, pred_e, pred_x = compute_loss(
-                    input_label, output, args)
+            total_loss, nll_loss, nll_loss_x, c_loss, c_loss_x, kl_loss, cpc_loss, pred_e, pred_x = \
+                compute_loss(input_label, output, args)
     
         all_nll_loss += nll_loss*(end-start)
         all_c_loss += c_loss*(end-start)


### PR DESCRIPTION
Hi Junwen, thanks for sharing the code for this interesting work. I have identified code that is perhaps redundant or only experimental for the dataset of interest and cleaned up `VAE`. I believe the updated version improves readability and helps paper readers understand better.

I have also run three different seeds using both the original codebase and my updated version:

Updated
````
HA : 0.9027973224405997, 0.9027866293120042, 0.9028080155691952
ebF1 : 0.5305065, 0.5325329, 0.53391516
miF1 : 0.5721814268532, 0.5741518991387162, 0.5737296868806976
maF1 : 0.44089374, 0.44260985, 0.4383079
p_at_1 : 0.7281592848435595, 0.7249085737505079, 0.7292970337261276
````
Original
````
HA : 0.902745995423341, 0.9028251245749481, 0.9025834598686884
ebF1 : 0.52963126, 0.53003454, 0.53117216
miF1 : 0.5723263066569747, 0.5697213044784142, 0.5716814444104726
maF1 : 0.43565962, 0.43977055, 0.43652895
p_at_1 : 0.729134498171475, 0.729134498171475, 0.7297846403900853
````
I believe there is no significant difference between the two implementations, though the conclusion is made without further investigation on statistics. It would be great if you could help review the code. 

I also removed the test script and the existing `vae-ckpt` because they are not consistent with how checkpoint saving is written in the code.

By checking the code, I notice
- eq.5 in the paper is not included (https://github.com/JunwenBai/c-gmvae/issues/2#issuecomment-1489430175);
- and two samples (`z` and `z2`) are decoded and used for CE.
Interestingly, by using only one `z` the performance is not as good and I thought upscaling `nll_coeff` might have achieved a similar effect as using two samples. It would be great to learn from your comments, if possible.